### PR TITLE
Added async version of join_task_result

### DIFF
--- a/capmonster_python/capmonster.py
+++ b/capmonster_python/capmonster.py
@@ -1,4 +1,6 @@
 import requests
+import asyncio
+
 from time import sleep
 from .utils import *
 
@@ -37,6 +39,16 @@ class Capmonster:
             elif result is False:
                 i += 1
                 sleep(2)
+        raise CapmonsterException(61, "ERROR_MAXIMUM_TIME_EXCEED", "Maximum time is exceed.")
+
+    async def async_join_task_result(self, task_id: int, maximum_time: int = 120):
+        for i in range(0, maximum_time + 1, 2):
+            result = self.get_task_result(task_id)
+            if result is not False and result is not None:
+                return result
+            elif result is False:
+                i += 1
+                await asyncio.sleep(2)
         raise CapmonsterException(61, "ERROR_MAXIMUM_TIME_EXCEED", "Maximum time is exceed.")
 
     @staticmethod

--- a/capmonster_python/capmonster.py
+++ b/capmonster_python/capmonster.py
@@ -1,6 +1,5 @@
 import requests
 import asyncio
-
 from time import sleep
 from .utils import *
 
@@ -41,7 +40,7 @@ class Capmonster:
                 sleep(2)
         raise CapmonsterException(61, "ERROR_MAXIMUM_TIME_EXCEED", "Maximum time is exceed.")
 
-    async def async_join_task_result(self, task_id: int, maximum_time: int = 120):
+    async def join_task_result_async(self, task_id: int, maximum_time: int = 120):
         for i in range(0, maximum_time + 1, 2):
             result = self.get_task_result(task_id)
             if result is not False and result is not None:


### PR DESCRIPTION
Added async version of join_task_result function.
We may use it to solve a couple of captcha simultaneously, or in case we do not want to wait until we get result and do some other stuff at the same time