### PR TITLE
fix: fixing the `TurnstileTask` class call and adding usage examples

### DIFF
--- a/capmonster_python/__init__.py
+++ b/capmonster_python/__init__.py
@@ -8,3 +8,4 @@ from .geetest import GeeTestTask
 from .utils import CapmonsterException
 from .compleximage import ComplexImageTask
 from .datadome import DataDomeTask
+from .turnstile import TurnstileTask

--- a/capmonster_python/turnstile.py
+++ b/capmonster_python/turnstile.py
@@ -1,8 +1,8 @@
-from .capmonster import Proxy
+from .capmonster import Proxy, UserAgent
 from typing import Union
 
 
-class TurnstileTask(Proxy):
+class TurnstileTask(UserAgent, Proxy):
     def __init__(self, client_key):
         super(TurnstileTask, self).__init__(client_key)
 
@@ -16,6 +16,7 @@ class TurnstileTask(Proxy):
                 "websiteKey": website_key
             }
         }
+        data, is_user_agent = self._add_user_agent(data)
         data, is_proxy = self._is_proxy_task(data)
         if no_cache:
             data["task"]["nocache"] = no_cache

--- a/docs/src/docs/usage/proxy-and-ua.mdx
+++ b/docs/src/docs/usage/proxy-and-ua.mdx
@@ -10,6 +10,7 @@ You can use proxy and user agent in supported tasks.
 - Fun captcha
 - HCaptcha
 - GeeTest
+- Turnstile
 
 > For GeeTest and HCaptcha, proxies with IP authorization are not yet supported.<br/>
 > For others, if the proxy is authorized by IP, then be sure to add **116.203.55.208** to the white list.
@@ -63,3 +64,16 @@ print(result.get("challenge"))
 print(result.get("seccode"))
 print(result.get("validate"))
 ```
+
+## Turnstile Usage
+```py title=turnstile_proxy.py
+from capmonster_python import TurnstileTask
+
+capmonster = TurnstileTask("API_KEY")
+capmonster.set_proxy("http", "8.8.8.8", 8080)
+capmonster.set_user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0")
+task_id = capmonster.create_task("website_url", "website_key")
+result = capmonster.join_task_result(task_id)
+print(result.get("token"))
+```
+

--- a/docs/src/docs/usage/solve-turnstile.mdx
+++ b/docs/src/docs/usage/solve-turnstile.mdx
@@ -14,9 +14,9 @@ description: Learn how to solve turnstile task
 ## Solve
 
 ```py title=solve_turnstile.py
-from capmonster_python import TurnstileV2Task
+from capmonster_python import TurnstileTask
 
-capmonster = TurnstileV2Task("API_KEY")
+capmonster = TurnstileTask("API_KEY")
 task_id = capmonster.create_task("website_url", "website_key")
 result = capmonster.join_task_result(task_id)
 print(result.get("token"))

--- a/examples/turnstile_request.py
+++ b/examples/turnstile_request.py
@@ -1,0 +1,44 @@
+import requests
+from re import search
+from bs4 import BeautifulSoup
+from capmonster_python import TurnstileTask
+
+
+class TurnstileRequest:
+    def __init__(self, _client_key: str):
+        self.captcha = TurnstileTask(_client_key)
+        self.s = requests.Session()
+        self.s.headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0"}
+        self.website_url = "http://tsmanaged.zlsupport.com"
+        self.expected = 'Success!'
+
+    def _form_html(self):
+        return self.s.get(self.website_url).text
+
+    def _site_token(self):
+        site_key = search(r"sitekey: '(.+?)'", BeautifulSoup(self._form_html(), "html.parser").find_all("script")[1].text).group(1)
+        print("# Site key found: {}".format(site_key))
+        task_id = self.captcha.create_task(website_url=self.website_url, website_key=site_key)
+        print("# Task created successfully")
+        result = self.captcha.join_task_result(task_id=task_id)
+        print("# Response received")
+        return result.get("token")
+
+    def submit_form(self):
+        result = self._site_token()
+        data = {
+            'username': 'test',
+            'password': 'test',
+            'token': result,
+        }
+        response = self.s.post(self.website_url+'/send', data=data, headers=self.s.headers, verify=False)
+        return BeautifulSoup(response.text, "html.parser").title.string
+
+
+if __name__ == "__main__":
+    from os import environ
+    client_key = environ["API_KEY"]
+    example_request = TurnstileRequest(client_key)
+    assert example_request.expected in example_request.submit_form()
+    print("# Submit succeed, test is OK")
+

--- a/examples/turnstile_selenium.py
+++ b/examples/turnstile_selenium.py
@@ -1,0 +1,51 @@
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.firefox.options import Options
+from selenium.webdriver.firefox.service import Service
+from webdriver_manager.firefox import GeckoDriverManager
+from capmonster_python import TurnstileTask
+from time import sleep
+
+
+class TurnstileSelenium:
+    def __init__(self, _client_key, _headless):
+        self.options = Options()
+        self.options.headless = _headless
+        self.user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0"
+        self.captcha = TurnstileTask(_client_key)
+        self.browser = webdriver.Firefox(service=Service(GeckoDriverManager().install()), options=self.options)
+        self.website_url = "http://tsmanaged.zlsupport.com"
+
+    def _get_site_key(self):
+        self.browser.get(self.website_url)
+        return self.browser.find_elements(By.TAG_NAME, "script")[1].get_attribute("innerHTML").split("sitekey: '")[1].split("'")[0]
+
+    def _solve_turnstile(self):
+        self.captcha.set_user_agent(self.user_agent)
+        task_id = self.captcha.create_task(website_url=self.website_url,
+                                           website_key=self._get_site_key(),
+                                           no_cache=True)
+        print("# Task created successfully with the following id: {}".format(task_id))
+        return self.captcha.join_task_result(task_id=task_id, maximum_time=180).get("token")
+
+    def submit_form(self):
+        token = self._solve_turnstile()
+        self.browser.find_element(By.NAME, "username").send_keys("test")
+        self.browser.find_element(By.NAME, "password").send_keys("test")
+        self.browser.execute_script(f"document.getElementById('token').value = '{token}'")
+        print("# Response received and placed to textarea")
+        self.browser.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+        sleep(5)
+        source = self.browser.find_element(By.TAG_NAME, "code")
+        self.browser.close()
+        return source
+
+
+if __name__ == "__main__":
+    from os import environ
+    client_key = environ["API_KEY"]
+    headless = environ["HEADLESS"]
+    environ["WDM_LOG_LEVEL"] = "0"
+    turnstile_selenium = TurnstileSelenium(client_key, headless)
+    assert turnstile_selenium.submit_form() is not None
+    print("# Submit is succeed, test is OK")


### PR DESCRIPTION
Hi! I started using the package for a project of mine, but I noticed that the call to `TurnstileTask` wasn't working [according to the documentation](https://capmonster-python.quasm.dev/usage/solve-turnstile) . So I looked into this and noticed that `TurnstileTask` was as `TurnstileV2Task` in the package documentation, however, the [CapMonster documentation on Turnstile](https://docs.capmonster.cloud/docs/captchas/tunrstile-task/ ) does not mention `TurnstileV2Task` and class was not being called in `__init__.py`, so I decided to open this pull request by updating it to the correct call and adding it to `__init__.py`. Let me know if I'm wrong about this.

Anyway, I also took the opportunity to change the calls in the package documentation and added usage examples for `TurnstileTask`. I also added support for `set_user_agent` to `TurnstileTask` as I saw in the CapMonster documentation that they supported this too.